### PR TITLE
Make styling configurable

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -20,6 +20,7 @@
 
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "*";
 
 body {
   padding: 20px 0;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -20,7 +20,7 @@
 
 @import "font-awesome-sprockets";
 @import "font-awesome";
-@import "*";
+@import "extra/*";
 
 body {
   padding: 20px 0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,9 +4,11 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user
 
-  def index
-  end
+  layout ENV['LAYOUT'] || 'application'
 
+  def index
+    render "#{ENV['INDEX_TEMPLATE'] || 'index'}.html.erb"
+  end
 
   private
 


### PR DESCRIPTION
This allows someone who forks this code to:

a) Set the name of the homepage and / or layout via an environment variable; and
b) Add any style overrides into the `app/assets/stylesheets` folder, which will then get autoimported

This means they can make cosmetic changes and keep up to date with master without getting into a mess with git conflicts etc.