### PR TITLE
Send notification emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 
 group :development do
   gem 'pry-remote'
+  gem 'letter_opener'
 end
 
 gem 'omniauth-github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,10 @@ GEM
     json (1.8.3)
     jwt (1.5.4)
     kgio (2.10.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
@@ -364,6 +368,7 @@ DEPENDENCIES
   git
   jbuilder (~> 2.0)
   jquery-rails
+  letter_opener
   octokit
   odlifier
   omniauth-github

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -48,6 +48,9 @@ class DatasetsController < ApplicationController
     head :accepted
   end
 
+  def created
+  end
+
   def new
     @dataset = Dataset.new
   end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -51,6 +51,9 @@ class DatasetsController < ApplicationController
   def created
   end
 
+  def edited
+  end
+
   def new
     @dataset = Dataset.new
   end

--- a/app/mailers/dataset_mailer.rb
+++ b/app/mailers/dataset_mailer.rb
@@ -1,0 +1,10 @@
+class DatasetMailer < ActionMailer::Base
+  default from: "noreply@octopub.io"
+
+  def success(dataset)
+    @user = dataset.user
+    @dataset = dataset
+    mail(to: @user.email, subject: 'Your Octopub dataset has been created')
+  end
+
+end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -7,7 +7,7 @@ class Dataset < ActiveRecord::Base
   belongs_to :user
   has_many :dataset_files
 
-  after_create :create_in_github, :set_owner_avatar
+  after_create :create_in_github, :set_owner_avatar, :build_certificate, :send_success_email
   after_update :update_in_github
   after_destroy :delete_in_github
 
@@ -17,17 +17,28 @@ class Dataset < ActiveRecord::Base
   validate :check_repo, on: :create
   validates_associated :dataset_files
 
-  def self.create_certificate id
-    dataset = Dataset.find(id)
+  def send_success_email
+    DatasetMailer.success(self).deliver
+  end
 
-    cert = CertificateFactory::Certificate.new dataset.gh_pages_url
+  def build_certificate
+    status = user.octokit_client.pages(full_name).status
+    if status == "built"
+      create_certificate
+    else
+      sleep 5
+      build_certificate
+    end
+  end
+
+  def create_certificate
+    cert = CertificateFactory::Certificate.new gh_pages_url
 
     gen = cert.generate
 
     if gen[:success] == 'pending'
       result = cert.result
-      dataset.add_certificate_url(result[:certificate_url])
-      DatasetMailer.success(dataset).deliver
+      add_certificate_url(result[:certificate_url])
     end
   end
 

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -100,8 +100,9 @@ class Dataset < ActiveRecord::Base
   end
 
   def self.report_status(dataset, channel_id)
-    if dataset.save
+    if dataset.valid?
       Pusher[channel_id].trigger('dataset_created', dataset)
+      dataset.save
     else
       messages = dataset.errors.full_messages
       dataset.dataset_files.each do |file|

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -27,6 +27,7 @@ class Dataset < ActiveRecord::Base
     if gen[:success] == 'pending'
       result = cert.result
       dataset.add_certificate_url(result[:certificate_url])
+      DatasetMailer.success(dataset).deliver
     end
   end
 

--- a/app/views/dataset_mailer/success.html.erb
+++ b/app/views/dataset_mailer/success.html.erb
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Your dataset has been created</h1>
+    <p>
+      Hi <%= @user.name %>,
+    </p>
+    <p>
+      Just a quick note to let you know that your dataset, <%= @dataset.name %> has been created.
+      It's available to view at the link below:
+    </p>
+    <p>
+      <%= link_to @dataset.gh_pages_url, @dataset.gh_pages_url %>
+    </p>
+    <p>
+      We've also created an Open Data Certificate for your dataset.
+      If you have an Open Data Certificates account, you can claim the dataset and
+      answer additional questions at <%= link_to @dataset.certificate_url, @dataset.certificate_url %>.
+    </p>
+    <p>
+      To manage your Octopub datasets, you can access your <%= link_to 'dashboard', dashboard_url %>
+      at any time.
+    </p>
+
+    <p>
+      Thanks,<br />
+      The Octopub Team.
+    </p>
+
+  </body>
+</html>

--- a/app/views/dataset_mailer/success.html.erb
+++ b/app/views/dataset_mailer/success.html.erb
@@ -9,7 +9,7 @@
       Hi <%= @user.name %>,
     </p>
     <p>
-      Just a quick note to let you know that your dataset, <%= @dataset.name %> has been created.
+      Just a quick note to let you know that your dataset, '<pre><%= @dataset.name %></pre>' has been created.
       It's available to view at the link below:
     </p>
     <p>

--- a/app/views/dataset_mailer/success.html.erb
+++ b/app/views/dataset_mailer/success.html.erb
@@ -9,7 +9,7 @@
       Hi <%= @user.name %>,
     </p>
     <p>
-      Just a quick note to let you know that your dataset, '<pre><%= @dataset.name %></pre>' has been created.
+      Just a quick note to let you know that your dataset, '<code><%= @dataset.name %></code>' has been created.
       It's available to view at the link below:
     </p>
     <p>

--- a/app/views/dataset_mailer/success.html.erb
+++ b/app/views/dataset_mailer/success.html.erb
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <style type="text/css">
+    .emailContent{
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    }
+    </style>
   </head>
-  <body>
+  <body class="emailContent">
     <h1>Your dataset has been created</h1>
     <p>
       Hi <%= @user.name %>,
@@ -26,7 +31,7 @@
     </p>
 
     <p>
-      Thanks,<br />
+      Thanks,<br /><br />
       The Octopub Team.
     </p>
 

--- a/app/views/datasets/_dataset.html.erb
+++ b/app/views/datasets/_dataset.html.erb
@@ -6,14 +6,7 @@
   <td><%= dataset.name %></td>
   <td>
     <% if @dashboard %>
-      <% if dataset.build_status == nil %>
-        <p class="text-muted build-message">
-          <i class="fa fa-refresh fa-spin"></i> Building...
-        </p>
-        <%= link_to dataset.gh_pages_url, dataset.gh_pages_url, class: "hidden dataset-link", id: "link_#{dataset.id}" %>
-      <% else %>
-        <%= link_to dataset.gh_pages_url, dataset.gh_pages_url %>
-      <% end %>
+      <%= link_to dataset.gh_pages_url, dataset.gh_pages_url %>
     <% else %>
       <%= link_to dataset.gh_pages_url, dataset.gh_pages_url %>
     <% end %>

--- a/app/views/datasets/_form.html.erb
+++ b/app/views/datasets/_form.html.erb
@@ -109,7 +109,9 @@
     }
 
     function postForm(form) {
-      var channelID = '<%= SecureRandom.uuid %>'
+      var channelID = form.attr('method') + '-<%= SecureRandom.uuid %>'
+
+      console.log(channelID)
 
       $.ajax({
         type: form.attr('method'),
@@ -127,7 +129,11 @@
       var channel = pusher.subscribe(channelID);
 
       channel.bind('dataset_created', function(data) {
-        window.location = '/datasets/created'
+        if (channelID.match(/post/)) {
+          window.location = '/datasets/created'
+        } else {
+          window.location = '/datasets/edited'
+        }
       })
       channel.bind('dataset_failed', function(data) {
         addErrors(data)

--- a/app/views/datasets/_form.html.erb
+++ b/app/views/datasets/_form.html.erb
@@ -127,7 +127,7 @@
       var channel = pusher.subscribe(channelID);
 
       channel.bind('dataset_created', function(data) {
-        window.location = '/dashboard?success=true'
+        window.location = '/datasets/created'
       })
       channel.bind('dataset_failed', function(data) {
         addErrors(data)

--- a/app/views/datasets/created.html.erb
+++ b/app/views/datasets/created.html.erb
@@ -1,0 +1,10 @@
+<h1 class="page-header">Thank you!</h1>
+
+<p class="lead">
+  Your dataset has been queued for creation, and you should receive an email with
+  a link to your dataset on Github shortly.
+</p>
+
+<p>
+  If you haven't had an email after about five minutes, please check your spam filters.
+</p>

--- a/app/views/datasets/dashboard.html.erb
+++ b/app/views/datasets/dashboard.html.erb
@@ -16,19 +16,6 @@
 
       var pusher = new Pusher('<%= Pusher.key %>');
 
-      $('tr').each(function(i, r) {
-        row = $(r)
-        if (row.data('build-status') == "building") {
-          channelID = "buildStatus" + row.data('dataset-id')
-          channel = pusher.subscribe(channelID);
-
-          channel.bind('dataset_built', function(data) {
-            row.find('.build-message').addClass('hidden')
-            row.find('.dataset-link').removeClass('hidden')
-          })
-        }
-      })
-
       $('#refresh').click(function(e) {
 
         var channelID = 'datasetRefresh<%= current_user.id %>'

--- a/app/views/datasets/edited.html.erb
+++ b/app/views/datasets/edited.html.erb
@@ -1,0 +1,9 @@
+<h1 class="page-header">Thank you!</h1>
+
+<p class="lead">
+  Your edits have been queued for creation, and your edits should appear on Github shortly.
+</p>
+
+<p>
+  If you haven't had an email after about five minutes, please check your spam filters.
+</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,9 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.default_url_options = { host: "git-data-publisher.dev" }
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,4 +75,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: "octopub.io" }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,4 +77,13 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.default_url_options = { host: "octopub.io" }
+
+  config.action_mailer.smtp_settings = {
+    address: "smtp.mandrillapp.com",
+    port: 25,
+    enable_starttls_auto: true, #
+    user_name: ENV["MANDRILL_USERNAME"],
+    password: ENV["MANDRILL_PASSWORD"],
+    authentication: 'login'
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,8 +80,8 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     address: "smtp.mandrillapp.com",
-    port: 25,
-    enable_starttls_auto: true, #
+    port: 587,
+    enable_starttls_auto: true,
     user_name: ENV["MANDRILL_USERNAME"],
     password: ENV["MANDRILL_PASSWORD"],
     authentication: 'login'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     collection do
       get "/refresh", action: 'refresh'
       get "/created", action: 'created'
+      get "/edited", action: 'edited'
     end
     member do
       get "/files", action: :files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   resources :datasets do
     collection do
       get "/refresh", action: 'refresh'
+      get "/created", action: 'created'
     end
     member do
       get "/files", action: :files

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,6 @@ ActiveRecord::Schema.define(version: 20160719122740) do
     t.string   "owner_avatar"
     t.string   "build_status"
     t.string   "full_name"
-    t.string   "gh_pages_url"
     t.string   "certificate_url"
   end
 

--- a/spec/controllers/datasets/create_spec.rb
+++ b/spec/controllers/datasets/create_spec.rb
@@ -270,7 +270,7 @@ describe DatasetsController, type: :controller do
         expect(@user.datasets.count).to eq(1)
         expect(@user.datasets.first.dataset_files.count).to eq(1)
 
-        expect(response.body).to eq(@dataset.to_json)
+        expect(response.body).to match /#{Dataset.first.name}/
       end
 
       context('with a schema') do

--- a/spec/controllers/datasets/create_spec.rb
+++ b/spec/controllers/datasets/create_spec.rb
@@ -16,6 +16,8 @@ describe DatasetsController, type: :controller do
 
     Dataset.skip_callback(:create, :after, :create_in_github)
     Dataset.skip_callback(:create, :after, :set_owner_avatar)
+    Dataset.skip_callback(:create, :after, :build_certificate)
+    Dataset.skip_callback(:create, :after, :send_success_email)
 
     allow_any_instance_of(DatasetFile).to receive(:add_to_github) { nil }
     allow_any_instance_of(Dataset).to receive(:create_files) { nil }
@@ -24,6 +26,8 @@ describe DatasetsController, type: :controller do
   after(:each) do
     Dataset.set_callback(:create, :after, :create_in_github)
     Dataset.set_callback(:create, :after, :set_owner_avatar)
+    Dataset.set_callback(:create, :after, :build_certificate)
+    Dataset.set_callback(:create, :after, :send_success_email)
   end
 
   describe 'create dataset' do
@@ -284,8 +288,8 @@ describe DatasetsController, type: :controller do
           "owner_avatar": nil,
           "build_status": nil,
           "full_name":"user-mc-user/my-cool-repo",
-          "certificate_url": nil,
-          "gh_pages_url":"http://user-mcuser.github.io/my-cool-repo"
+          "gh_pages_url":"http://user-mcuser.github.io/my-cool-repo",
+          "certificate_url": nil
         }.to_json)
       end
 

--- a/spec/controllers/datasets/create_spec.rb
+++ b/spec/controllers/datasets/create_spec.rb
@@ -270,27 +270,7 @@ describe DatasetsController, type: :controller do
         expect(@user.datasets.count).to eq(1)
         expect(@user.datasets.first.dataset_files.count).to eq(1)
 
-        expect(response.body).to eq({
-          "id": Dataset.first.id,
-          "name":"My cool dataset",
-          "url": "https://github.com/user-mc-user/my-cool-repo",
-          "user_id":@user.id,
-          "created_at": Dataset.first.created_at,
-          "updated_at": Dataset.first.updated_at,
-          "repo":"my-cool-repo",
-          "description":"This is a description",
-          "publisher_name":"Cool inc",
-          "publisher_url":"http://example.com",
-          "license":"OGL-UK-3.0",
-          "frequency":"Monthly",
-          "datapackage_sha": nil,
-          "owner": nil,
-          "owner_avatar": nil,
-          "build_status": nil,
-          "full_name":"user-mc-user/my-cool-repo",
-          "gh_pages_url":"http://user-mcuser.github.io/my-cool-repo",
-          "certificate_url": nil
-        }.to_json)
+        expect(response.body).to eq(@dataset.to_json)
       end
 
       context('with a schema') do

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -11,6 +11,8 @@ FactoryGirl.define do
 
     after(:build) { |dataset|
       dataset.class.skip_callback(:create, :after, :create_in_github)
+      dataset.class.skip_callback(:create, :after, :build_certificate)
+      dataset.class.skip_callback(:create, :after, :send_success_email)
       dataset.class.skip_callback(:update, :after, :update_in_github)
       dataset.class.skip_callback(:create, :after, :set_owner_avatar)
 

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -664,7 +664,7 @@ describe Dataset do
 
       expect(@dataset).to receive(:add_certificate_url).with(@certificate_url)
 
-      Dataset.create_certificate(@dataset.id)
+      @dataset.create_certificate 
     end
 
     it 'adds the badge url to the repo' do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -85,13 +85,6 @@ describe Dataset do
 
         Dataset.create_dataset(@dataset, files, @user, perform_async: true, channel_id: "beep-beep")
       end
-
-      it "queues to check the build status" do
-        expect {
-          Dataset.create_dataset(@dataset, @files, @user, perform_async: true, channel_id: "beep-beep")
-        }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(1)
-      end
-
     end
 
   end
@@ -168,13 +161,6 @@ describe Dataset do
 
         dataset = Dataset.update_dataset(@dataset.id, @user, @dataset_params, files, perform_async: true, channel_id: "beep-beep")
       end
-
-      it "queues to check the build status" do
-        expect {
-           Dataset.update_dataset(@dataset.id, @user, @dataset_params, @files, perform_async: true, channel_id: "beep-beep")
-        }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(1)
-      end
-
     end
 
   end
@@ -576,61 +562,6 @@ describe Dataset do
 
   end
 
-  context 'checks the build status of a dataset' do
-
-    before(:each) do
-      @dataset = create(:dataset)
-      allow(@dataset).to receive(:full_name) { "theodi/blockchain-and-distributed-technology-landscape-research" }
-    end
-
-    after(:each) do
-      Sidekiq::Extensions::DelayedClass.jobs.clear
-    end
-
-    context 'when built' do
-      before(:each) do
-        expect(@dataset.user.octokit_client).to receive(:pages).with(@dataset.full_name) {
-          stub = double(Sawyer::Resource)
-          expect(stub).to receive(:status) { "built" }
-          stub
-        }
-
-        mock_client = mock_pusher("buildStatus#{@dataset.id}")
-        expect(mock_client).to receive(:trigger).with('dataset_built', {})
-      end
-
-      it 'returns straight away' do
-        Dataset.check_build_status(@dataset)
-
-        expect(@dataset.build_status).to eq('built')
-      end
-
-      it 'queues up a certificate creation' do
-        Dataset.check_build_status(@dataset)
-
-        expect(Sidekiq::Extensions::DelayedClass.jobs.count).to eq(1)
-        expect(Sidekiq::Extensions::DelayedClass.jobs[0]["args"][0]).to match(/create_certificate/)
-        expect(Sidekiq::Extensions::DelayedClass.jobs[0]["args"][0]).to match(/#{@dataset.id}/)
-      end
-
-    end
-
-    it 'requeues if dataset is not built yet' do
-      expect(@dataset.user.octokit_client).to receive(:pages).with(@dataset.full_name) {
-        stub = double(Sawyer::Resource)
-        expect(stub).to receive(:status) { "building" }
-        stub
-      }
-
-      expect {
-        Dataset.check_build_status(@dataset)
-      }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(1)
-
-      expect(@dataset.build_status).to eq(nil)
-    end
-
-  end
-
   context 'creating certificates' do
 
     before(:each) do
@@ -638,9 +569,6 @@ describe Dataset do
       @certificate_url = 'http://staging.certificates.theodi.org/en/datasets/162441/certificate.json'
       allow(@dataset).to receive(:full_name) { "theodi/blockchain-and-distributed-technology-landscape-research" }
       allow(@dataset).to receive(:gh_pages_url) { "http://theodi.github.io/blockchain-and-distributed-technology-landscape-research" }
-      allow(Dataset).to receive(:find).with(@dataset.id) {
-        @dataset
-      }
     end
 
     it 'creates a certificate' do
@@ -664,7 +592,7 @@ describe Dataset do
 
       expect(@dataset).to receive(:add_certificate_url).with(@certificate_url)
 
-      @dataset.create_certificate 
+      @dataset.create_certificate
     end
 
     it 'adds the badge url to the repo' do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -571,6 +571,34 @@ describe Dataset do
       allow(@dataset).to receive(:gh_pages_url) { "http://theodi.github.io/blockchain-and-distributed-technology-landscape-research" }
     end
 
+    it 'waits for the page build to finish' do
+      allow_any_instance_of(User).to receive(:octokit_client) {
+        client = double(Octokit::Client)
+        allow(client).to receive(:pages).with(@dataset.full_name) {
+          OpenStruct.new(status: 'pending')
+        }
+        client
+      }
+
+      expect(@dataset).to receive(:build_certificate)
+
+      @dataset.send :build_certificate
+    end
+
+    it 'creates the certificate when build is complete' do
+      allow_any_instance_of(User).to receive(:octokit_client) {
+        client = double(Octokit::Client)
+        allow(client).to receive(:pages).with(@dataset.full_name) {
+          OpenStruct.new(status: 'built')
+        }
+        client
+      }
+
+      expect(@dataset).to receive(:create_certificate)
+
+      @dataset.send :build_certificate
+    end
+
     it 'creates a certificate' do
       factory = double(CertificateFactory::Certificate)
 

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -592,7 +592,7 @@ describe Dataset do
 
       expect(@dataset).to receive(:add_certificate_url).with(@certificate_url)
 
-      @dataset.create_certificate
+      @dataset.send(:create_certificate)
     end
 
     it 'adds the badge url to the repo' do
@@ -604,7 +604,7 @@ describe Dataset do
       }.to_yaml)
       expect(@dataset).to receive(:push_to_github)
 
-      @dataset.add_certificate_url(@certificate_url)
+      @dataset.send(:add_certificate_url, @certificate_url)
 
       expect(@dataset.certificate_url).to eq('http://staging.certificates.theodi.org/en/datasets/162441/certificate')
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,7 +75,6 @@ describe User do
 
     before(:each) do
       @user = create(:user, token: ENV['GITHUB_TOKEN'])
-
       @dataset1 = create(:dataset, full_name: 'git-data-publisher/api-sandbox', user: @user)
       @dataset2 = create(:dataset, full_name: 'octopub-data/juan-test', user: create(:user))
     end


### PR DESCRIPTION
Rather than just spinning, this sends users to a thank you page and delivers an email once the grunt work has been done. We need to add our Mandrill creds to Heroku before merging this for email delivery to work.