### PR TITLE
In the tests, the fake file method was confusingly named - rename it

### DIFF
--- a/spec/api/create_spec.rb
+++ b/spec/api/create_spec.rb
@@ -123,7 +123,7 @@ describe 'POST /datasets' do
 
     before(:each) do
       schema_path = File.join(Rails.root, 'spec', 'fixtures', 'schemas', 'good-schema.json')
-      @schema = fake_file(schema_path)
+      @schema = url_with_stubbed_get_for(schema_path)
     end
 
     it 'creates a dataset sucessfully' do

--- a/spec/controllers/datasets/create_spec.rb
+++ b/spec/controllers/datasets/create_spec.rb
@@ -37,7 +37,7 @@ describe DatasetsController, type: :controller do
         @files << {
           :title => name,
           :description => description,
-          :file => fake_file(path)
+          :file => url_with_stubbed_get_for(path)
         }
 
       end
@@ -102,7 +102,7 @@ describe DatasetsController, type: :controller do
         @files << {
           :title => name,
           :description => description,
-          :file => fake_file(path)
+          :file => url_with_stubbed_get_for(path)
         }
 
         @repo = double(GitData)
@@ -241,7 +241,7 @@ describe DatasetsController, type: :controller do
 
       before(:each) do
         schema_path = File.join(Rails.root, 'spec', 'fixtures', 'schemas', 'good-schema.json')
-        @schema = fake_file(schema_path)
+        @schema = url_with_stubbed_get_for(schema_path)
       end
 
       context 'returns an error if the file does not match the schema' do
@@ -253,7 +253,7 @@ describe DatasetsController, type: :controller do
           @files << {
             :title => 'My File',
             :description => 'My Description',
-            :file => fake_file(path)
+            :file => url_with_stubbed_get_for(path)
           }
 
           @dataset = {
@@ -297,7 +297,7 @@ describe DatasetsController, type: :controller do
         @files << {
           :title => 'My File',
           :description => 'My Description',
-          :file => fake_file(path)
+          :file => url_with_stubbed_get_for(path)
         }
 
         request = post :create, params: { dataset: {

--- a/spec/controllers/datasets/update_spec.rb
+++ b/spec/controllers/datasets/update_spec.rb
@@ -59,7 +59,7 @@ describe DatasetsController, type: :controller do
           it 'updates a file in Github' do
             filename = 'valid-schema.csv'
             path = File.join(Rails.root, 'spec', 'fixtures', filename)
-            file = fake_file(path)
+            file = url_with_stubbed_get_for(path)
 
             expect(@file).to receive(:update_in_github)
             expect(@file).to receive(:update_jekyll_in_github)
@@ -77,7 +77,7 @@ describe DatasetsController, type: :controller do
 
               @filename = 'valid-schema.csv'
               @path = File.join(Rails.root, 'spec', 'fixtures', @filename)
-              @new_file = fake_file(@path)
+              @new_file = url_with_stubbed_get_for(@path)
 
               file = build(:dataset_file, dataset: @dataset, file: nil)
 
@@ -143,7 +143,7 @@ describe DatasetsController, type: :controller do
         it 'updates a file in Github' do
           filename = 'test-data.csv'
           path = File.join(Rails.root, 'spec', 'fixtures', filename)
-          file = fake_file(path)
+          file = url_with_stubbed_get_for(path)
 
           expect(@file).to receive(:update_in_github)
           expect(@file).to receive(:update_jekyll_in_github)
@@ -159,7 +159,7 @@ describe DatasetsController, type: :controller do
 
           filename = 'test-data.csv'
           path = File.join(Rails.root, 'spec', 'fixtures', filename)
-          file = fake_file(path)
+          file = url_with_stubbed_get_for(path)
 
           new_file = build(:dataset_file, dataset: @dataset, file: nil)
 
@@ -199,7 +199,7 @@ describe DatasetsController, type: :controller do
           @file.file = nil
           filename = 'invalid-schema.csv'
           path = File.join(Rails.root, 'spec', 'fixtures', filename)
-          file = fake_file(path)
+          file = url_with_stubbed_get_for(path)
 
           expect(@file).to_not receive(:update_in_github)
 
@@ -221,7 +221,7 @@ describe DatasetsController, type: :controller do
 
             @filename = 'invalid-schema.csv'
             @path = File.join(Rails.root, 'spec', 'fixtures', @filename)
-            @new_file = fake_file(@path)
+            @new_file = url_with_stubbed_get_for(@path)
 
             file = build(:dataset_file, dataset: @dataset, file: nil)
 

--- a/spec/jobs/create_dataset_spec.rb
+++ b/spec/jobs/create_dataset_spec.rb
@@ -20,7 +20,7 @@ describe CreateDataset do
       ActiveSupport::HashWithIndifferentAccess.new(
         title: 'My File',
         description: 'My description',
-        file: fake_file(File.join(Rails.root, 'spec', 'fixtures', 'test-data.csv'))
+        file: url_with_stubbed_get_for(File.join(Rails.root, 'spec', 'fixtures', 'test-data.csv'))
       )
     ]
 
@@ -64,7 +64,7 @@ describe CreateDataset do
       {
         'title' => 'My File',
         'description' => Faker::Company.bs,
-        'file' => fake_file(path)
+        'file' => url_with_stubbed_get_for(path)
       }
     ]
 
@@ -86,7 +86,7 @@ describe CreateDataset do
       {
         'title' => 'My File',
         'description' => Faker::Company.bs,
-        'file' => fake_file(path)
+        'file' => url_with_stubbed_get_for(path)
       }
     ]
 

--- a/spec/jobs/update_dataset_spec.rb
+++ b/spec/jobs/update_dataset_spec.rb
@@ -37,7 +37,7 @@ describe UpdateDataset do
       {
         'title' => 'My File',
         'description' => Faker::Company.bs,
-        'file' => fake_file(path)
+        'file' => url_with_stubbed_get_for(path)
       }
     ]
   end
@@ -70,7 +70,7 @@ describe UpdateDataset do
         {
           'title' => 'My File',
           'description' => Faker::Company.bs,
-          'file' => fake_file(path)
+          'file' => url_with_stubbed_get_for(path)
         }
       ]
     end

--- a/spec/models/dataset_file_spec.rb
+++ b/spec/models/dataset_file_spec.rb
@@ -188,7 +188,7 @@ describe DatasetFile do
 
     before(:each) do
       schema_path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/good-schema.json')
-      @dataset = build(:dataset, schema: fake_file(schema_path))
+      @dataset = build(:dataset, schema: url_with_stubbed_get_for(schema_path))
     end
 
     it 'validates against a schema with good data' do
@@ -225,7 +225,7 @@ describe DatasetFile do
   context 'with csv-on-the-web schema' do
     before :each do
       schema_path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/csv-on-the-web-schema.json')
-      @dataset = build(:dataset, schema: fake_file(schema_path))
+      @dataset = build(:dataset, schema: url_with_stubbed_get_for(schema_path))
     end
 
     it 'validates with good data' do
@@ -261,7 +261,7 @@ describe DatasetFile do
   context 'with multiple csv-on-the-web files' do
     before :each do
       schema_path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/multiple-csvs-on-the-web-schema.json')
-      @dataset = build(:dataset, schema: fake_file(schema_path))
+      @dataset = build(:dataset, schema: url_with_stubbed_get_for(schema_path))
     end
 
     it 'validates with good data' do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -253,7 +253,7 @@ describe Dataset do
                                 dataset_files: [
                                   create(:dataset_file, :with_good_schema)
                                 ],
-                                schema: fake_file(schema_path)
+                                schema: url_with_stubbed_get_for(schema_path)
 
       expect(dataset).to receive(:add_file_to_repo).with("data/my-awesome-dataset.csv", File.open(File.join(Rails.root, 'spec', 'fixtures', 'valid-schema.csv')).read)
       expect(dataset).to receive(:add_file_to_repo).with("datapackage.json", dataset.create_json_datapackage) { {content: {} }}
@@ -334,7 +334,7 @@ describe Dataset do
   context "schemata" do
     it 'is unhappy with a duff schema' do
       path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/bad-schema.json')
-      schema = fake_file(path)
+      schema = url_with_stubbed_get_for(path)
       dataset = build(:dataset, schema: schema)
 
       expect(dataset.valid?).to be false
@@ -343,7 +343,7 @@ describe Dataset do
 
     it 'is happy with a good schema' do
       path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/good-schema.json')
-      schema = fake_file(path)
+      schema = url_with_stubbed_get_for(path)
       dataset = build(:dataset, schema: schema)
 
       expect(dataset.valid?).to be true
@@ -351,7 +351,7 @@ describe Dataset do
 
     it 'adds the schema to the datapackage' do
       path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/good-schema.json')
-      schema = fake_file(path)
+      schema = url_with_stubbed_get_for(path)
       file = create(:dataset_file, filename: "example.csv",
                                    title: "My Awesome File",
                                    description: "My Awesome File Description")
@@ -403,7 +403,7 @@ describe Dataset do
   context 'csv-on-the-web schema' do
     it 'is unhappy with a duff schema' do
       path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/duff-csv-on-the-web-schema.json')
-      schema = fake_file(path)
+      schema = url_with_stubbed_get_for(path)
       dataset = build(:dataset, schema: schema)
 
       expect(dataset.valid?).to be false
@@ -412,7 +412,7 @@ describe Dataset do
 
     it 'does not add the schema to the datapackage' do
       path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/csv-on-the-web-schema.json')
-      schema = fake_file(path)
+      schema = url_with_stubbed_get_for(path)
       file = create(:dataset_file, filename: "example.csv",
                                    title: "My Awesome File",
                                    description: "My Awesome File Description")
@@ -425,7 +425,7 @@ describe Dataset do
 
     it "creates JSON files on GitHub when using a CSVW schema" do
       path = File.join(Rails.root, 'spec', 'fixtures', 'schemas/csv-on-the-web-schema.json')
-      schema = fake_file(path)
+      schema = url_with_stubbed_get_for(path)
       dataset = build :dataset, schema: schema
 
       file = create(:dataset_file, dataset: dataset,

--- a/spec/requests/dataset_creation_spec.rb
+++ b/spec/requests/dataset_creation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Dataset creation", type: :request do
     @files << {
       :title => file_name,
       :description => description,
-      :file => fake_file(path)
+      :file => url_with_stubbed_get_for(path)
     }
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,7 @@ def set_api_key(user)
   request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Token.encode_credentials(user.api_key)
 end
 
-def fake_file path
+def url_with_stubbed_get_for path
   url = "https://example.org/uploads/#{SecureRandom.uuid}/somefile.csv"
   stub_request(:get, url).to_return(body: File.read(path))
   url


### PR DESCRIPTION
It has been renamed to ```url_with_stubbed_get_for(path)```