### PR TITLE
Configure airbrake so it ignores development

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -41,7 +41,7 @@ Airbrake.configure do |c|
   # environments.
   # NOTE: This option *does not* work if you don't set the 'environment' option.
   # https://github.com/airbrake/airbrake-ruby#ignore_environments
-  c.ignore_environments = %w(test)
+  c.ignore_environments = %w(development test)
 
   # A list of parameters that should be filtered out of what is sent to
   # Airbrake. By default, all "password" attributes will have their contents


### PR DESCRIPTION
Makes it easier to work on without having to set up airbrake environment.

Default config configures development, which is then problematic if you don't have airbrake set up. I'm surprised it isn't the default to be honest!