### PR TITLE
Don’t publish public views for private repositories

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -33,7 +33,7 @@ class Dataset < ApplicationRecord
   has_many :dataset_files
   belongs_to :dataset_schema
 
-  after_create :create_repo_and_populate, :set_owner_avatar, :publish_publicly, :send_success_email, :send_tweet_notification
+  after_create :create_repo_and_populate, :set_owner_avatar, :publish_public_views, :send_success_email, :send_tweet_notification
   after_update :update_in_github
   after_destroy :delete_in_github
 
@@ -262,7 +262,15 @@ class Dataset < ApplicationRecord
       end
     end
 
-    def publish_publicly
+    def publish_public_views
+      return if private
+      # Later we'll want to make sure this is called on create or when things are
+      # made public, and that different action is taken if an already-public dataset
+      # is updated.
+      create_public_views
+    end
+
+    def create_public_views
       create_jekyll_files
       push_to_github
       wait_for_gh_pages_build

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
 
     after(:build) { |dataset|
       skip_callback_if_exists( Dataset, :create, :after, :create_repo_and_populate)
-      skip_callback_if_exists( Dataset, :create, :after, :publish_publicly)
+      skip_callback_if_exists( Dataset, :create, :after, :publish_public_views)
       skip_callback_if_exists( Dataset, :create, :after, :send_success_email)
       skip_callback_if_exists( Dataset, :update, :after, :update_in_github)
       skip_callback_if_exists( Dataset, :create, :after, :set_owner_avatar)
@@ -21,6 +21,7 @@ FactoryGirl.define do
     trait :with_callback do
       after(:build) { |dataset|
         dataset.class.set_callback(:create, :after, :create_repo_and_populate)
+        dataset.class.set_callback(:create, :after, :publish_public_views)
         dataset.class.set_callback(:update, :after, :update_in_github)
       }
     end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -76,6 +76,7 @@ describe Dataset do
     }
 
     expect(dataset).to receive(:add_files_to_repo_and_push_to_github)
+    expect(dataset).to receive(:create_public_views)
 
     dataset.save
     dataset.reload
@@ -97,6 +98,7 @@ describe Dataset do
     }
 
     expect(dataset).to receive(:add_files_to_repo_and_push_to_github)
+    expect(dataset).to receive(:create_public_views)
 
     dataset.save
   end
@@ -522,7 +524,7 @@ describe Dataset do
       expect(@dataset).to receive(:gh_pages_built?).and_return(true).once
       expect(@dataset).to receive(:create_certificate).once
 
-      @dataset.send :publish_publicly
+      @dataset.send :publish_public_views
     end
 
     it 'creates a certificate' do
@@ -595,6 +597,7 @@ describe Dataset do
       }
 
       expect(dataset).to receive(:add_files_to_repo_and_push_to_github)
+      expect(dataset).not_to receive(:create_public_views)
 
       dataset.save
       dataset.reload

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,14 +85,14 @@ end
 def skip_dataset_callbacks!
   skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
   skip_callback_if_exists(Dataset, :create, :after, :set_owner_avatar)
-  skip_callback_if_exists(Dataset, :create, :after, :publish_publicly)
+  skip_callback_if_exists(Dataset, :create, :after, :publish_public_views)
   skip_callback_if_exists(Dataset, :create, :after, :send_success_email)
 end
 
 def set_dataset_callbacks!
   Dataset.set_callback(:create, :after, :create_repo_and_populate)
   Dataset.set_callback(:create, :after, :set_owner_avatar)
-  Dataset.set_callback(:create, :after, :publish_publicly)
+  Dataset.set_callback(:create, :after, :publish_public_views)
   Dataset.set_callback(:create, :after, :send_success_email)
 end
 


### PR DESCRIPTION
Part of #204, this PR
* [x] only does HTML views and certification for public repositories
* [x] triggers HTML/cert stuff when a public dataset is created
* [ ] triggers HTML/cert stuff when a private dataset is made public
* [ ] update HTML/cert when public datasets are updated