### PR TITLE
This task allows the DB to be dropped in development mode.

### DIFF
--- a/config/initializers/postgres_database_drop_task.rb
+++ b/config/initializers/postgres_database_drop_task.rb
@@ -1,0 +1,14 @@
+# config/initializers/postgresql_database_tasks.rb
+module ActiveRecord
+  module Tasks
+    class PostgreSQLDatabaseTasks
+      def drop
+        if Rails.env.development?
+          establish_master_connection
+          connection.select_all "select pg_terminate_backend(pg_stat_activity.pid) from pg_stat_activity where datname='#{configuration['database']}' AND state='idle';"
+          connection.drop_database configuration['database']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This little task allows all sessions to be terminated in Dev mode only on a db:drop

It's a handy utility