### PR TITLE
Fix JS and markup for cloning file sections for both edit and new

### DIFF
--- a/app/views/dataset_files/_edit_form.html.erb
+++ b/app/views/dataset_files/_edit_form.html.erb
@@ -1,19 +1,21 @@
-<fieldset class="file bg-upload">
-  <div class="well bg-info">
-    <%= f.text_field "files[][title]", label: "Title", class: "title", value: file.title, placeholder: t(:'dataset_file.name'), readonly: !file.id.nil? %>
-    <%= f.text_area "files[][description]", label: "Description", class: "description", value: file.description, placeholder: t(:'dataset_file.description') %>
-    <% if file.filename %>
-      <div class="form-group filename-wrapper">
-        <div class="current-file">
-          <label class="control-label">
-            Current file
-          </label>
-          <p><%= link_to file.filename, file.gh_pages_url %> <%= f.check_box "Change file #{i}", label: "Change file", class: "change-file" %> </p>
+<div class="file-panel">
+  <fieldset class="file bg-upload">
+    <div class="well bg-info">
+      <%= f.text_field "files[][title]", label: "Title", class: "title", value: file.title, placeholder: t(:'dataset_file.name'), readonly: !file.id.nil? %>
+      <%= f.text_area "files[][description]", label: "Description", class: "description", value: file.description, placeholder: t(:'dataset_file.description') %>
+      <% if file.filename %>
+        <div class="form-group filename-wrapper">
+          <div class="current-file">
+            <label class="control-label">
+              Current file
+            </label>
+            <p><%= link_to file.filename, file.gh_pages_url %> <%= f.check_box "Change file #{i}", label: "Change file", class: "change-file" %> </p>
+          </div>
         </div>
-      </div>
-    <% else %>
-      <%= f.file_field "files[][file]", label: "File", accept: ".csv" %>
-    <% end %>
-    <%= f.hidden_field("files[][id]", name: "files[][id]", value: file.id) if file.id %>
-  </div>
-</fieldset>
+      <% else %>
+        <%= f.file_field "files[][file]", label: "File", accept: ".csv" %>
+      <% end %>
+      <%= f.hidden_field("files[][id]", name: "files[][id]", value: file.id) if file.id %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/dataset_files/_new_form.html.erb
+++ b/app/views/dataset_files/_new_form.html.erb
@@ -1,5 +1,5 @@
 <h2>Files</h2>
-<div class="file-and-schema">
+<div class="file-panel">
   <div class="panel panel-default">
     <div class="panel-heading">Data Files</div>
       <div class="panel-body">

--- a/app/views/datasets/_extra_js.html.erb
+++ b/app/views/datasets/_extra_js.html.erb
@@ -111,16 +111,16 @@
   }
 
   $(document).ready(function() {
-    var file = $('.file-and-schema:first').clone();
+    var file = $('div.file-panel:first').clone();
 
     // Clone button to create another file to upload
     $('#clone').click(function(e) {
       e.preventDefault();
-      clone = $(file).clone()
-      clone.find('.title').attr('required', 'required')
+      clone = $(file).clone();
+      clone.find('.title').attr('required', 'required');
       clone.appendTo('#files');
       clone.find('.bg-upload').each(function(i, elem) {
-        bgUpload(elem)
+        bgUpload(elem);
       });
     });
 


### PR DESCRIPTION
Mark up had changed between edit and new, so edit couldn't add new file sections. Fixed now. This is a fix for #256 