### PR TITLE
Fix tests to clean properly and use unique emails

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,8 +2,9 @@ FactoryGirl.define do
   factory :user do
     provider "github"
     uid "1234556"
-    email "user@example.com"
-    name "User"
+    email Faker::Internet.unique.email
+    name Faker::Name.unique.name
     token "rwefsadasfesesds3454353few"
+    #password "this-has-to-be-longer-than-six-characters"
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -64,9 +64,9 @@ describe ApplicationHelper do
   it 'gets user option' do
     expect(helper.user_option).to eq(
       [
-        'user',
+        @user.github_username,
         nil,
-        { 'data-content' => "<img src='http://www.example.org/avatar2.png' height='20' width='20' /> user" }
+        { 'data-content' => "<img src='http://www.example.org/avatar2.png' height='20' width='20' /> #{@user.github_username}" }
       ]
     )
   end
@@ -74,9 +74,9 @@ describe ApplicationHelper do
   it 'gets all options' do
     expect(helper.organization_select_options).to eq([
       [
-        'user',
+        @user.github_username,
         nil,
-        { 'data-content' => "<img src='http://www.example.org/avatar2.png' height='20' width='20' /> user" }
+        { 'data-content' => "<img src='http://www.example.org/avatar2.png' height='20' width='20' /> #{@user.github_username}" }
       ],
       [
         'org1',

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   config.include FactoryGirl::Syntax::Methods
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,9 +56,37 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
+  # Request specs cannot use a transaction because Capybara runs in a
+  # separate thread with a different database connection.
+  config.before type: :request do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  # Reset so other non-request specs don't have to deal with slow truncation.
+  config.after type: :request  do
+    DatabaseCleaner.strategy = :transaction
+  end
+
 
   # This config option will be enabled by default on RSpec 4,
   # but for reasons of backwards compatibility, you have to


### PR DESCRIPTION
Configure database cleaner correctly and generate unique emails  …
Because it wasn't set up right and was leaving data around
	Fix this test which was relying on hard coded user details