### PR TITLE
Tweak size of dataset icons

### DIFF
--- a/app/views/datasets/_dataset.html.erb
+++ b/app/views/datasets/_dataset.html.erb
@@ -6,9 +6,9 @@
   <% if @dashboard %>
     <td class="private">
       <% if dataset.restricted %>
-        <i class='fa fa-lock' title="private"></i>
+        <i class='fa fa-lock fa-lg' title="private"></i>
       <% else %>
-        <i class='fa fa-globe' title="public"></i>
+        <i class='fa fa-globe fa-lg' title="public"></i>
       <% end %>
     </td>
   <% end %>

--- a/spec/views/_dataset_spec.rb
+++ b/spec/views/_dataset_spec.rb
@@ -41,20 +41,21 @@ describe 'datasets/_dataset.html.erb' do
 
   it 'displays access icon in the dashboard' do
     @dashboard = true
-    
+
     render :partial => 'datasets/dataset.html.erb', :locals => {:dataset => @dataset}
     page = Nokogiri::HTML(rendered)
     expect(page.css('tr')[0].css('td').count).to eq(6)
-    expect(page.css('tr')[0].css('td')[1].inner_html).to match('<i class="fa fa-globe" title="public"></i>')
+    expect(page.css('tr:first-child > td:nth-child(2)')).to have_css('i.fa.fa-globe');
+    expect(page.css('tr:first-child > td:nth-child(2)')).to have_css('i[title="public"]');
   end
 
   it 'displays private icon in the dashboard' do
     @dashboard = true
-    
+
     render :partial => 'datasets/dataset.html.erb', :locals => {:dataset => @restricted_dataset}
     page = Nokogiri::HTML(rendered)
     expect(page.css('tr')[0].css('td').count).to eq(6)
-    expect(page.css('tr')[0].css('td')[1].inner_html).to match('<i class="fa fa-lock" title="private"></i>')
+    expect(page.css('tr:first-child > td:nth-child(2)')).to have_css('i.fa.fa-lock');
+    expect(page.css('tr:first-child > td:nth-child(2)')).to have_css('i[title="private"]');
   end
-
 end


### PR DESCRIPTION
Dataset icons were a little tiddly - just increased the size and also made the tests slightly less rigid.