### PR TITLE
Move it move it

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -33,7 +33,6 @@ class Dataset < ApplicationRecord
   belongs_to :user
   has_many :dataset_files
 
-  after_create :create_repo_and_populate
   after_update :update_dataset_in_github, :make_repo_public_if_appropriate, :publish_public_views
   after_destroy :delete_dataset_in_github
 
@@ -47,6 +46,7 @@ class Dataset < ApplicationRecord
       Pusher[channel_id].trigger('dataset_created', self) if channel_id
       Rails.logger.info "Dataset: Valid so now do the save and trigger the after creates"
       save
+      CreateRepository.perform_async(id)
     else
       Rails.logger.info "Dataset: In valid, so push to pusher"
       messages = errors.full_messages
@@ -115,12 +115,6 @@ class Dataset < ApplicationRecord
   end
 
   private
-
-    # This is a callback
-    def create_repo_and_populate
-      Rails.logger.info "in NEW create_repo_and_populate"
-      CreateRepository.perform_async(id)
-    end
 
     # This is a callback
     def update_dataset_in_github

--- a/spec/api/create_files_spec.rb
+++ b/spec/api/create_files_spec.rb
@@ -4,7 +4,7 @@ describe 'POST /datasets/:id/files' do
 
   before(:each) do
     Sidekiq::Testing.inline!
-    skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
+    allow_any_instance_of(CreateRepository).to receive(:perform)
 
     @filename = 'test-data.csv'
     @storage_key = "uploads/#{SecureRandom.uuid}/#{@filename}"
@@ -21,7 +21,6 @@ describe 'POST /datasets/:id/files' do
 
   after(:each) do
     Sidekiq::Testing.fake!
-    Dataset.set_callback(:create, :after, :create_repo_and_populate)
   end
 
   it 'creates a new file' do

--- a/spec/api/create_spec.rb
+++ b/spec/api/create_spec.rb
@@ -4,8 +4,6 @@ describe 'POST /datasets' do
 
   before(:each) do
     Sidekiq::Testing.inline!
-    skip_dataset_callbacks!
-
     @user = create(:user)
 
     @name = "My cool dataset"
@@ -26,7 +24,6 @@ describe 'POST /datasets' do
 
     @storage_key = "uploads/#{SecureRandom.uuid}/#{filename}"
 
-    Dataset.set_callback(:create, :after, :create_repo_and_populate)
     allow_any_instance_of(Dataset).to receive(:complete_publishing)
 
     @repo = double(GitData)

--- a/spec/api/update_files_spec.rb
+++ b/spec/api/update_files_spec.rb
@@ -6,8 +6,7 @@ describe 'PUT /datasets/:id/files/:file_id', vcr: { :match_requests_on => [:host
 
   before(:each) do
     Sidekiq::Testing.inline!
-
-    skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
+    allow_any_instance_of(CreateRepository).to receive(:perform)
     skip_callback_if_exists(Dataset, :update, :after, :update_dataset_in_github)
 
     @user = create(:user)
@@ -25,7 +24,6 @@ describe 'PUT /datasets/:id/files/:file_id', vcr: { :match_requests_on => [:host
 
   after(:each) do
     Sidekiq::Testing.fake!
-    Dataset.set_callback(:create, :after, :create_repo_and_populate)
     Dataset.set_callback(:update, :after, :update_dataset_in_github)
   end
 

--- a/spec/api/update_spec.rb
+++ b/spec/api/update_spec.rb
@@ -4,9 +4,8 @@ describe 'PUT /datasets/:id' do
 
   before(:each) do
     Sidekiq::Testing.inline!
-    skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
     skip_callback_if_exists(Dataset, :update, :after, :update_dataset_in_github)
-   
+    allow_any_instance_of(CreateRepository).to receive(:perform)
     @user = create(:user)
     @dataset = create(:dataset, name: "Dataset", user: @user, dataset_files: [
       create(:dataset_file, filename: 'test-data.csv')
@@ -18,7 +17,6 @@ describe 'PUT /datasets/:id' do
 
   after(:each) do
     Sidekiq::Testing.fake!
-    Dataset.set_callback(:create, :after, :create_repo_and_populate)
     Dataset.set_callback(:update, :after, :update_dataset_in_github)
   end
 

--- a/spec/controllers/datasets/create_spec.rb
+++ b/spec/controllers/datasets/create_spec.rb
@@ -13,7 +13,6 @@ describe DatasetsController, type: :controller do
 
   before(:each) do
     Sidekiq::Testing.inline!
-    skip_dataset_callbacks!
 
     @user = create(:user)
     sign_in @user
@@ -47,7 +46,6 @@ describe DatasetsController, type: :controller do
 
   after(:each) do
     Sidekiq::Testing.fake!
-    set_dataset_callbacks!
   end
 
   describe 'do not create dataset' do
@@ -112,7 +110,6 @@ describe DatasetsController, type: :controller do
   end
 
   describe 'create dataset' do
-
     context 'with one file' do
 
       before(:each) do
@@ -121,8 +118,6 @@ describe DatasetsController, type: :controller do
         filename = 'test-data.csv'
         path = File.join(Rails.root, 'spec', 'fixtures', filename)
         @storage_key = "uploads/#{SecureRandom.uuid}/#{filename}"
-
-        Dataset.set_callback(:create, :after, :create_repo_and_populate)
 
         @files << {
           :title => name,
@@ -137,8 +132,6 @@ describe DatasetsController, type: :controller do
         expect(@repo).to receive(:name) { nil }
         expect(@repo).to receive(:full_name) { nil }
         expect(@repo).to receive(:save)
-
-
       end
 
       def creation_assertions

--- a/spec/controllers/datasets/create_with_existing_schema_spec.rb
+++ b/spec/controllers/datasets/create_with_existing_schema_spec.rb
@@ -21,12 +21,12 @@ describe DatasetsController, type: :controller, vcr: { :match_requests_on => [:h
 
   before(:each) do
     Sidekiq::Testing.inline!
-    skip_dataset_callbacks!
 
     @user = create(:user)
     sign_in @user
     allow_any_instance_of(JekyllService).to receive(:create_data_files) { nil }
     allow_any_instance_of(JekyllService).to receive(:create_jekyll_files) { nil }
+    allow_any_instance_of(CreateRepository).to receive(:perform)
 
     @url_for_schema = url_for_schema_with_stubbed_get_for(schema_path)
 
@@ -43,7 +43,6 @@ describe DatasetsController, type: :controller, vcr: { :match_requests_on => [:h
 
   after(:each) do
     Sidekiq::Testing.fake!
-    set_dataset_callbacks!
   end
 
   describe 'create dataset with an existing schema' do

--- a/spec/controllers/datasets/create_with_new_schema_spec.rb
+++ b/spec/controllers/datasets/create_with_new_schema_spec.rb
@@ -20,12 +20,12 @@ describe DatasetsController, type: :controller, vcr: { :match_requests_on => [:h
 
   before(:each) do
     Sidekiq::Testing.inline!
-    skip_dataset_callbacks!
 
     @user = create(:user)
     sign_in @user
     allow_any_instance_of(JekyllService).to receive(:create_data_files) { nil }
     allow_any_instance_of(JekyllService).to receive(:create_jekyll_files) { nil }
+    allow_any_instance_of(CreateRepository).to receive(:perform)
 
     @url_for_schema = url_for_schema_with_stubbed_get_for(schema_path)
     @files ||= []
@@ -33,7 +33,6 @@ describe DatasetsController, type: :controller, vcr: { :match_requests_on => [:h
 
   after(:each) do
     Sidekiq::Testing.fake!
-    set_dataset_callbacks!
   end
 
   describe 'create dataset with a new schema' do

--- a/spec/controllers/datasets/update_spec.rb
+++ b/spec/controllers/datasets/update_spec.rb
@@ -18,12 +18,10 @@ describe DatasetsController, type: :controller, vcr: { :match_requests_on => [:h
 
   before(:each) do
     Sidekiq::Testing.inline!
-
     @user = create(:user)
-    skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
-
     allow_any_instance_of(JekyllService).to receive(:create_data_files) { nil }
     allow_any_instance_of(JekyllService).to receive(:create_jekyll_files) { nil }
+    allow_any_instance_of(CreateRepository).to receive(:perform)
   end
 
   before(:each, schema: true) do
@@ -32,8 +30,6 @@ describe DatasetsController, type: :controller, vcr: { :match_requests_on => [:h
 
   after(:each) do
     Sidekiq::Testing.fake!
-
-    Dataset.set_callback(:create, :after, :create_repo_and_populate)
   end
 
   describe 'update' do

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -10,14 +10,12 @@ FactoryGirl.define do
     association :user, factory: :user
 
     after(:build) { |dataset|
-      skip_callback_if_exists( Dataset, :create, :after, :create_repo_and_populate)
       skip_callback_if_exists( Dataset, :update, :after, :update_dataset_in_github)
       dataset.instance_variable_set(:@repo, FakeData.new)
     }
 
     trait :with_callback do
       after(:build) { |dataset|
-        dataset.class.set_callback(:create, :after, :create_repo_and_populate)
         dataset.class.set_callback(:update, :after, :update_dataset_in_github)
       }
     end

--- a/spec/features/add_dataset_spec.rb
+++ b/spec/features/add_dataset_spec.rb
@@ -9,7 +9,6 @@ feature "Add dataset page", type: :feature do
   let(:data_file) { get_fixture_file('valid-schema.csv') }
 
   before(:each) do
-    skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
     visit root_path
   end
 

--- a/spec/features/edit_dataset_spec.rb
+++ b/spec/features/edit_dataset_spec.rb
@@ -17,8 +17,6 @@ feature "Edit dataset page", type: :feature do
     allow(UpdateDataset).to receive(:perform_async) do |a,b,c,d,e|
       UpdateDataset.new.perform(a,b,c,d,e)
     end
-
-    skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
     good_schema_url = url_with_stubbed_get_for_fixture_file('schemas/good-schema.json')
     create(:dataset_file_schema, url_in_repo: good_schema_url, name: 'good schema', description: 'good schema description', user: @user)
     @dataset = create(:dataset, name: dataset_name, user: @user, license: "CC-BY-4.0", description: dataset_description)

--- a/spec/features/update_dataset_spec.rb
+++ b/spec/features/update_dataset_spec.rb
@@ -12,8 +12,6 @@ feature "Update dataset page", type: :feature do
   let(:good_schema_url) { url_with_stubbed_get_for_fixture_file('schemas/good-schema.json') }
 
   before(:each) do
-    Dataset.set_callback(:update, :after, :create_repo_and_populate)
-    skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
     visit root_path
     allow_any_instance_of(JekyllService).to receive(:license_details) {
       object = double(Object)
@@ -21,10 +19,6 @@ feature "Update dataset page", type: :feature do
       allow(object).to receive(:title) { 'licence' }
       object
     }
-  end
-
-  after(:each) do
-    skip_callback_if_exists(Dataset, :update, :after, :create_repo_and_populate)
   end
 
   context "logged in visitor has a dataset and" do
@@ -46,9 +40,7 @@ feature "Update dataset page", type: :feature do
       allow_any_instance_of(UpdateDataset).to receive(:handle_files) do |a,b|
         {}
       end
-      allow_any_instance_of(Dataset).to receive(:create_repo_and_populate)
       allow_any_instance_of(Dataset).to receive(:fetch_repo)
-
     end
 
     scenario "can access edit dataset page and change description" do
@@ -68,7 +60,6 @@ feature "Update dataset page", type: :feature do
   context "logged in visitor has a dataset with a dataset file schema and" do
 
     before(:each) do
-      skip_dataset_callbacks!
       expect(Dataset.count).to be 0
       @dataset_file_schema = DatasetFileSchemaService.new(schema_name, schema_description, good_schema_url, @user).create_dataset_file_schema
       good_file = url_with_stubbed_get_for_fixture_file('valid-schema.csv')
@@ -95,13 +86,7 @@ feature "Update dataset page", type: :feature do
       allow_any_instance_of(UpdateDataset).to receive(:handle_files) do |a,b|
         {}
       end
-      allow_any_instance_of(Dataset).to receive(:create_repo_and_populate)
       allow_any_instance_of(Dataset).to receive(:fetch_repo)
-
-    end
-
-    after(:each) do
-      set_dataset_callbacks!
     end
 
     scenario "can access edit dataset page and change description" do

--- a/spec/jobs/check_repository_is_created_spec.rb
+++ b/spec/jobs/check_repository_is_created_spec.rb
@@ -3,10 +3,9 @@ require 'rails_helper'
 describe CheckRepositoryIsCreated do
 
   before(:each) do
-
     @worker = CheckRepositoryIsCreated.new
     @user = create(:user)
-    name = "My Awesome Dataset"  
+    name = "My Awesome Dataset"
     full_name = "my-cool-organization/#{name.parameterize}"
     @dataset = create(:dataset, user: @user, name: name)
 
@@ -21,37 +20,9 @@ describe CheckRepositoryIsCreated do
     }
   end
 
-  after(:each) do
-    set_dataset_callbacks!
-  end
-
   it 'and updates columns' do
     @worker.perform(@dataset.id)
     @dataset.reload
     expect(@dataset.url).to eq(@html_url)
   end
-
-  # it 'calls the next thing in the queue' do
-  #   Sidekiq::Testing.inline!
-  #   @worker.perform(@dataset.id)
-    
-  #   allow_any_instance_of(CreateJekyllFilesAndPushToGithub).to receive(:perform).with(@dataset_id).and_return { nil }
-  #   Sidekiq::Testing.fake!
-  # end
-
 end
-
-  # def perform(dataset_id)
-  #   Rails.logger.info "in CheckRepositoryIsCreated"
-  #   dataset = Dataset.find(dataset_id)
-  #   # Throws Octokit not found if not there!
-  #   repo = GitData.find(dataset.repo_owner, dataset.name, client: dataset.user.octokit_client)
-
-  #   Rails.logger.info "Repo is found in CheckRepositoryIsCreated"
-  #   # Now do the adding to the repository
-  #   # Update column so don't trigger callback
-  #   dataset.update_columns(url: repo.html_url, repo: repo.name, full_name: repo.full_name)
-  #   Rails.logger.info "Now updated dataset with github details - call commit!"
-
-  #   CreateJekyllFilesAndPushToGithub.perform_async(dataset_id)
-  # end

--- a/spec/jobs/create_dataset_spec.rb
+++ b/spec/jobs/create_dataset_spec.rb
@@ -1,12 +1,9 @@
 require 'rails_helper'
 
 describe CreateDataset do
-
   before(:each) do
-    skip_dataset_callbacks!
 
     @worker = CreateDataset.new
-
     @dataset_params = {
       name: "My Awesome Dataset",
       description: "An awesome dataset",
@@ -15,15 +12,10 @@ describe CreateDataset do
       license: "OGL-UK-3.0",
       frequency: "One-off",
     }
-
     @user = create(:user)
   end
 
-  after(:each) do
-    set_dataset_callbacks!
-  end
-
-  context 'without a schema' do 
+  context 'without a schema' do
 
     let(:filename) { 'test-data.csv' }
     let(:storage_key) { filename }

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -93,6 +93,7 @@ describe Dataset, vcr: { :match_requests_on => [:host, :method] } do
     allow_any_instance_of(Dataset).to receive(:complete_publishing)
 
     dataset.save
+    CreateRepository.new.perform(dataset.id)
     dataset.reload
 
     expect(dataset.repo).to eq(name.parameterize)
@@ -120,6 +121,7 @@ describe Dataset, vcr: { :match_requests_on => [:host, :method] } do
     expect_any_instance_of(Dataset).to receive(:complete_publishing)
 
     dataset.save
+    CreateRepository.new.perform(dataset.id)
   end
 
   it "completes publishing" do
@@ -253,6 +255,7 @@ describe Dataset, vcr: { :match_requests_on => [:host, :method] } do
       expect_any_instance_of(Dataset).to receive(:complete_publishing)
 
       dataset.save
+      CreateRepository.new.perform(dataset.id)
       dataset.reload
 
       expect(dataset.repo).to eq(name.parameterize)
@@ -281,6 +284,7 @@ describe Dataset, vcr: { :match_requests_on => [:host, :method] } do
 
       expect_any_instance_of(Dataset).to receive(:complete_publishing)
       dataset.save
+      CreateRepository.new.perform(dataset.id)
 
       # Update dataset and make public
       updated_dataset = Dataset.find(dataset.id)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,8 +4,6 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
-
-
 require 'spec_helper'
 require 'rspec/rails'
 
@@ -94,44 +92,6 @@ RSpec.configure do |config|
         obj
       end
     end
-
-    # allow(Odlifier::License).to receive(:define).with("cc-by") {
-    #   obj = double(Odlifier::License)
-    #   allow(obj).to receive(:title) { "Creative Commons Attribution 4.0" }
-    #   allow(obj).to receive(:id) { "CC-BY-4.0" }
-    #   obj
-    # }
-    # allow(Odlifier::License).to receive(:define).with("cc-by-sa") {
-    #   obj = double(Odlifier::License)
-    #   allow(obj).to receive(:title) { "Creative Commons Attribution Share-Alike 4.0" }
-    #   allow(obj).to receive(:id) { "CC-BY-SA-4.0" }
-    #   obj
-    # }
-    # allow(Odlifier::License).to receive(:define).with("cc0") {
-    #   obj = double(Odlifier::License)
-    #   allow(obj).to receive(:title) { "CC0 1.0" }
-    #   allow(obj).to receive(:id) { "CC0-1.0" }
-    #   obj
-    # }
-    # allow(Odlifier::License).to receive(:define).with("OGL-UK-3.0") {
-    #   obj = double(Odlifier::License)
-    #   allow(obj).to receive(:title) { "Open Government Licence 3.0 (United Kingdom)" }
-    #   allow(obj).to receive(:id) { "OGL-UK-3.0" }
-    #   obj
-    # }
-    # allow(Odlifier::License).to receive(:define).with("odc-by") {
-    #   obj = double(Odlifier::License)
-    #   allow(obj).to receive(:title) { "Open Data Commons Attribution License 1.0" }
-    #   allow(obj).to receive(:id) { "ODC-BY-1.0" }
-    #   obj
-    # }
-    # allow(Odlifier::License).to receive(:define).with("odc-pddl") {
-    #   obj = double(Odlifier::License)
-    #   allow(obj).to receive(:title) { "Open Data Commons Public Domain Dedication and Licence 1.0" }
-    #   allow(obj).to receive(:id) { "ODC-PDDL-1.0" }
-    #   obj
-    # }
-
   end
 
   # This overrides always true in the spec_helper file
@@ -220,14 +180,6 @@ def mock_pusher(channel_id)
   mock_client = double(Pusher::Channel)
   expect(Pusher).to receive(:[]).with(channel_id) { mock_client }
   mock_client
-end
-
-def skip_dataset_callbacks!
-  skip_callback_if_exists(Dataset, :create, :after, :create_repo_and_populate)
-end
-
-def set_dataset_callbacks!
-  Dataset.set_callback(:create, :after, :create_repo_and_populate)
 end
 
 def skip_callback_if_exists(thing, name, kind, filter)

--- a/spec/requests/dataset_creation_spec.rb
+++ b/spec/requests/dataset_creation_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Dataset creation", type: :request, vcr: { :match_requests_on => 
   before(:each) do
 
     Sidekiq::Testing.fake!
-    skip_dataset_callbacks!
 
     @user = create(:user)
     sign_in @user
@@ -30,8 +29,6 @@ RSpec.describe "Dataset creation", type: :request, vcr: { :match_requests_on => 
     description = Faker::Company.bs
     filename = 'test-data.csv'
     path = File.join(Rails.root, 'spec', 'fixtures', filename)
-
-    Dataset.set_callback(:create, :after, :create_repo_and_populate)
 
     @files << {
       :title => file_name,


### PR DESCRIPTION
So, shifting the responsibility for the creation of the repository (and everything that follows) from a callback in Dataset to the job which actually does it. The idea being that the logic about what happens to the Dataset is more than just the dataset's responsibility.