### PR TITLE
enable typeahead on schema select boxes

### DIFF
--- a/app/views/dataset_files/_edit_form.html.erb
+++ b/app/views/dataset_files/_edit_form.html.erb
@@ -7,7 +7,7 @@
         <div class="alert alert-warning" role="alert"><b>Warning</b> This file has been validated against the schema <%= link_to file.dataset_file_schema.name, dataset_file_schema_path(file.dataset_file_schema) %> and if you change the file, it will also be validated against that schema.</div>
       <% end %>
 
-      <%= f.select "files[][dataset_file_schema_id]", options_from_collection_for_select(dataset_file_schemas, :id, :name,  selected_dataset_file_schema_id(file, @default_schema).to_s), { prompt: 'No schema required', label: 'Dataset file schemas'} %>
+      <%= f.select "files[][dataset_file_schema_id]", options_from_collection_for_select(dataset_file_schemas, :id, :name,  selected_dataset_file_schema_id(file, @default_schema).to_s), { prompt: 'No schema required', label: 'Dataset file schemas'}, {'data-live-search': "true", class: 'selectpicker'} %>
 
       <% if file.filename %>
         <div class="form-group filename-wrapper">

--- a/app/views/dataset_files/_new_form.html.erb
+++ b/app/views/dataset_files/_new_form.html.erb
@@ -29,7 +29,7 @@
 
         <% if dataset_file_schemas.any? %>
           <h4>Choose an existing schema</h4>
-          <%= f.select "files[][dataset_file_schema_id]", options_from_collection_for_select(dataset_file_schemas, :id, :name), { prompt: 'No schema required', label: 'Existing dataset schemas' } %>
+          <%= f.select "files[][dataset_file_schema_id]", options_from_collection_for_select(dataset_file_schemas, :id, :name), { prompt: 'No schema required', label: 'Existing dataset schemas'}, {'data-live-search': "true", class: 'selectpicker'} %>
           <h4>Or upload a new one</h4>
         <% else %>
           <h4>Upload a schema for this Data File</h4>


### PR DESCRIPTION
This PR fixes #409 

Changes proposed in this pull request:
- enable bootstrap-select search box on schema select boxes: https://silviomoreto.github.io/bootstrap-select/examples/#live-search