### PR TITLE
only choose JSON files for schema upload

### DIFF
--- a/app/views/dataset_files/_new_form.html.erb
+++ b/app/views/dataset_files/_new_form.html.erb
@@ -39,7 +39,7 @@
 
         <%= f.text_field "files[][schema_name]", label: "Schema name", value: schema.name, placeholder: t(:'dataset.schema.name') %>
         <%= f.text_area "files[][schema_description]", label: "Schema description", value: schema.description, placeholder: t(:'dataset.schema.description') %>
-        <div><%= f.file_field "files[][schema]", label: "File" %></div>
+        <div><%= f.file_field "files[][schema]", label: "File", accept: ".json" %></div>
       </fieldset>
     </div>
   </div>


### PR DESCRIPTION
Only choose JSON files for schema upload. The standalone schema upload form already does this.
