### PR TITLE
Use CanCanCan to manage authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'jsontableschema', git: 'https://github.com/Floppy/jsontableschema-rb', bran
 
 # User related
 gem 'omniauth-github'
-
+gem 'cancancan', '~> 2.0'
 
 # Bootstrap and view stuff
 gem 'bootstrap-sass', '~> 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.1.0)
+    cancancan (2.0.0)
     capybara (2.15.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -534,6 +535,7 @@ DEPENDENCIES
   bootstrap_form
   bundler-audit
   byebug
+  cancancan (~> 2.0)
   certificate-factory
   coderay
   coveralls (~> 0.8.21)
@@ -596,4 +598,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/controllers/allocated_dataset_file_schema_datasets_controller.rb
+++ b/app/controllers/allocated_dataset_file_schema_datasets_controller.rb
@@ -43,10 +43,6 @@ class AllocatedDatasetFileSchemaDatasetsController < ApplicationController
     render 'new' unless flash.empty?
   end
 
-  def check_signed_in?
-    render_403 if current_user.nil?
-  end
-
   def set_direct_post
     @s3_direct_post = FileStorageService.private_presigned_post
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do |exception|
+    Rails.logger.debug "Access denied on #{exception.action} #{exception.subject.inspect}"
     render_403
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,10 @@ class ApplicationController < ActionController::Base
     render_403 if current_user.nil?
   end
 
+  rescue_from CanCan::AccessDenied do |exception|
+    render_403
+  end
+
   private
 
   def current_user

--- a/app/controllers/dataset_file_schemas_controller.rb
+++ b/app/controllers/dataset_file_schemas_controller.rb
@@ -1,6 +1,7 @@
 class DatasetFileSchemasController < ApplicationController
   before_action :check_signed_in?
   before_action :set_dataset_file_schema, only: [:show, :edit, :update, :destroy]
+  authorize_resource
 
   def index
     @dataset_file_schemas = DatasetFileSchema.where(user: current_user).order(created_at: :desc)

--- a/app/controllers/dataset_file_schemas_controller.rb
+++ b/app/controllers/dataset_file_schemas_controller.rb
@@ -1,5 +1,4 @@
 class DatasetFileSchemasController < ApplicationController
-  before_action :check_signed_in?
   before_action :set_dataset_file_schema, only: [:show, :edit, :update, :destroy]
   authorize_resource
 

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -2,8 +2,6 @@ class DatasetsController < ApplicationController
   include FileHandlingForDatasets
 
   before_action :redirect_to_api, only: [:index, :show, :files, :dashboard]
-  before_action :check_signed_in?, only: [:show, :files, :edit, :dashboard, :update, :create, :new]
-  before_action :check_permissions, only: [:show, :files, :edit, :update, :delete]
   before_action :get_dataset, only: [:show, :files, :edit, :destroy]
   before_action :get_multipart, only: [:create, :update]
   before_action :clear_files, only: [:create, :update]
@@ -12,6 +10,8 @@ class DatasetsController < ApplicationController
   before_action :set_licenses, only: [:create, :new, :edit, :update]
   before_action :set_direct_post, only: [:edit, :new]
   before_action(only: :index) { alternate_formats [:json, :feed] }
+  
+  authorize_resource
 
   skip_before_action :verify_authenticity_token, only: [:create, :update], if: Proc.new { !current_user.nil? }
 
@@ -123,16 +123,8 @@ class DatasetsController < ApplicationController
     params[:dataset].try(:permit, [:description, :publisher_name, :publisher_url, :license, :frequency, :schema, :schema_name, :schema_description, :dataset_file_schema_id, :publishing_method])
   end
 
-  def check_signed_in?
-    render_403 if current_user.nil?
-  end
-
   def set_direct_post
     @s3_direct_post = FileStorageService.private_presigned_post
-  end
-
-  def check_permissions
-    render_403 unless current_user.all_dataset_ids.include?(params[:id].to_i)
   end
   
   def available_schemas

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,4 @@ class UsersController < ApplicationController
       params.require(:user).permit(:email, :twitter_handle)
     end
 
-    def check_signed_in?
-      render_403 if current_user.nil?
-    end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,16 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    if user
+      # A user can manage their datasets
+      can :manage, Dataset, :user => user
+      # and their schemas
+      can :manage, DatasetFileSchema, :user => user
+    end
+    # Everyone can read public datasets
+    can :read, Dataset, publishing_method: "github_public"
+    # and public schemas
+    can :read, DatasetFileSchema, restricted: false
+  end
+end

--- a/app/views/dataset_file_schemas/_schema_table.html.erb
+++ b/app/views/dataset_file_schemas/_schema_table.html.erb
@@ -28,7 +28,7 @@
           </td>
         <% end %>
         <td>
-          <% if dataset_file_schema.user == current_user || admin_user %>
+          <% if can? :delete, dataset_file_schema %>
             <%= link_to("Delete", dataset_file_schema_path(dataset_file_schema), method: :delete, data: { confirm: "Are you sure you want to delete this dataset file schema?" }, class: "btn btn-danger btn-sm") %>
           <% end %>
         </td>

--- a/app/views/datasets/_dataset.html.erb
+++ b/app/views/datasets/_dataset.html.erb
@@ -34,8 +34,10 @@
           end%></td>
   <td><%= dataset.created_at.to_formatted_s(:short) %></td>
   <td>
-    <% if dataset.user == current_user %>
+    <% if can? :edit, dataset %>
       <%= link_to("Edit", edit_dataset_path(dataset.id), class: "btn btn-warning") %>
+    <% end %>
+    <% if can? :delete, dataset %>
       <%= link_to("Delete", dataset_path(dataset.id), method: :delete, data: { confirm: "Are you sure you want to delete this dataset?\r\n\r\nNote: This will also delete the repo from Github" }, class: "btn btn-danger") %>
     <% end %>
   </td>

--- a/spec/controllers/dataset_file_schemas_controller_spec.rb
+++ b/spec/controllers/dataset_file_schemas_controller_spec.rb
@@ -333,7 +333,7 @@ describe DatasetFileSchemasController, type: :controller do
   
     it "can be switch from public to private and vice versa" do      
       expect(FileStorageService).to receive(:push_public_object).twice
-      schema = create :dataset_file_schema
+      schema = create :dataset_file_schema, user_id: @user.id, owner_username: @user.name
       expect(schema.restricted).to eq true      
       post :update, params: { id: schema.id, dataset_file_schema: {  restricted: false }}
       schema.reload

--- a/spec/features/public_access_spec.rb
+++ b/spec/features/public_access_spec.rb
@@ -42,7 +42,8 @@ feature "A visiting, non-logged in user", type: :feature do
       visit new_dataset_path 
     end
     it "edit dataset path" do 
-      visit edit_dataset_path(1)
+      @dataset = FactoryGirl.create(:dataset)
+      visit edit_dataset_path(@dataset.id)
     end
     it "new dashboard path" do 
       visit dashboard_path 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -103,10 +103,18 @@ RSpec.configure do |config|
       mocks.verify_partial_doubles = true
     end
   end
-end
 
-def current_user
-  @user
+  # This overrides always true in the spec_helper file
+  # Added to allow stubbing of current_user in view specs:
+  # https://github.com/rspec/rspec-rails/issues/1076
+  config.around(:each, type: :view) do |ex|
+    config.mock_with :rspec do |mocks|
+      mocks.verify_partial_doubles = false
+      ex.run
+      mocks.verify_partial_doubles = true
+    end
+  end
+
 end
 
 def compare_schemas_after_processing(original, compare_to)

--- a/spec/views/_dataset_spec.rb
+++ b/spec/views/_dataset_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
-describe 'datasets/_dataset.html.erb' do
+describe 'datasets/_dataset.html.erb', :view do
 
   before(:each) do
     @user = create(:user)
+    allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(@user)
     @dataset = create(:dataset, name: "My Dataset", repo: "my-repo", user: @user)
     allow_any_instance_of(DatasetFile).to receive(:check_schema)
     @dataset_with_schema = create(:dataset, name: "My Dataset", repo: "my-repo", user: @user,

--- a/spec/views/_datasets_spec.rb
+++ b/spec/views/_datasets_spec.rb
@@ -4,6 +4,7 @@ describe 'datasets/_datasets.html.erb' do
 
   before(:each) do
     @user = create(:user, name: "user")
+    allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(@user)
   end
 
   it "should display a number of datasets" do


### PR DESCRIPTION
As prep for allowing admins to do more tasks, I've converted the app to use CanCanCan for managing authorization of users. This gives a more meaningful syntax, plus centralisation of checking whether users can do things or not. This PR has no functionality changes - tests should stay the same (apart from a couple of differences in stub requirements).