### PR TITLE
add link to wiki in doc page

### DIFF
--- a/app/views/application/getting-started.html.erb
+++ b/app/views/application/getting-started.html.erb
@@ -138,6 +138,9 @@
       Once the file has uploaded, you can scroll down and click 'Submit' to create your dataset. You'll then see a notice telling you your data has been queued for creation. Within a few minutes, you should recieve an email, with a link allowing you to see your dataset in all its glory!
     </p>
 
+    <p>
+      For more information and advanced topics, visit the <a href='https://github.com/theodi/octopub/wiki'>Octopub wiki pages</a>.
+    </p>
 
   </div>
 


### PR DESCRIPTION
I've added some documentation on advanced topics to the wiki pages, so I've added a link here to them for people to follow if they needs more help.