### PR TITLE
rename Owner to Organization in the UI

### DIFF
--- a/app/views/dataset_file_schemas/_schema_table.html.erb
+++ b/app/views/dataset_file_schemas/_schema_table.html.erb
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th data-sortable="true">Creator</th>
-      <th data-sortable="true">Owner</th>
+      <th data-sortable="true"><%= t(:'dataset_file_schema.owner') %></th>
       <th data-sortable="true">Name</th>
       <th data-sortable="true">Type</th>
       <th data-sortable="true">Datasets using schema</th>

--- a/app/views/dataset_file_schemas/new.html.erb
+++ b/app/views/dataset_file_schemas/new.html.erb
@@ -7,7 +7,7 @@
   <% if SchemaCategory.any? %>
     <%= f.collection_check_boxes :schema_category_ids, SchemaCategory.all, :id, :name, label: 'Schema Categories' %>
   <% end %>
-  <%= f.select :owner_username, organization_select_options, { label: "Owner" }, { class: "selectpicker form-control show-tick" } %>
+  <%= f.select :owner_username, organization_select_options, { label: t(:'dataset_file_schema.owner') }, { class: "selectpicker form-control show-tick" } %>
   <div class="schema-panel">
     <fieldset class="file bg-upload">
       <%= f.file_field :url_in_s3, label: "File", accept: ".json" %>
@@ -18,5 +18,3 @@
     Submit <i class="fa fa-refresh fa-spin hidden" id="spinner"></i>
   </button>
 <% end %>
-
-

--- a/app/views/dataset_files/index.html.erb
+++ b/app/views/dataset_files/index.html.erb
@@ -4,7 +4,7 @@
     <thead>
       <tr>
         <th>Dataset Name</th>
-        <th>Owner</th>
+        <th><%= t(:'dataset.owner') %></th>
         <th>Title</th>
         <th>File Name</th>
         <th>File Description</th>

--- a/app/views/datasets/_datasets.html.erb
+++ b/app/views/datasets/_datasets.html.erb
@@ -7,7 +7,7 @@
   data-filter-control="true">
   <thead>
     <tr>
-      <th data-sortable="true">Owner</th>
+      <th data-sortable="true"><%= t(:'dataset.owner') %></th>
       <th>Type</th>
       <th data-sortable="true">Name</th>
       <th data-sortable="true">Schemas?</th>

--- a/app/views/datasets/_edit_form.html.erb
+++ b/app/views/datasets/_edit_form.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_tag url: url, method: method, html: { class: 'edit-form' }, data: { 'form-data' => (s3_direct_post.fields), 'url' => s3_direct_post.url, 'host' => URI.parse(s3_direct_post.url).host } do |f| %>
   <%= f.text_field "dataset[name]", label: "Dataset name", value: dataset.name, disabled: !dataset.id.nil?, required: true, placeholder: t(:'dataset.name') %>
   <% if dataset.id.nil? %>
-    <%= f.select "dataset[owner]", organization_select_options, { label: "Owner" }, { class: "selectpicker form-control show-tick" } %>
+    <%= f.select "dataset[owner]", organization_select_options, { label: t(:'dataset.owner') }, { class: "selectpicker form-control show-tick" } %>
   <% end %>
   <%= f.text_area "dataset[description]", label: "Dataset description", value: dataset.description, placeholder: t(:'dataset.description')  %>
   <%= f.text_field "dataset[publisher_name]", label: "Publisher name", value: dataset.publisher_name, required: true, placeholder: t(:'dataset.publisher_name') %>

--- a/app/views/datasets/_new_form.html.erb
+++ b/app/views/datasets/_new_form.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_tag url: url, method: method, data: { 'form-data' => (s3_direct_post.fields), 'url' => s3_direct_post.url, 'host' => URI.parse(s3_direct_post.url).host } do |f| %>
   <%= f.text_field "dataset[name]", label: "Dataset name", value: dataset.name, disabled: !dataset.id.nil?, required: true, placeholder: t(:'dataset.name') %>
   <% if dataset.id.nil? %>
-    <%= f.select "dataset[owner]", organization_select_options, { label: "Owner" }, { class: "selectpicker form-control show-tick" } %>
+    <%= f.select "dataset[owner]", organization_select_options, { label: t(:'dataset.owner') }, { class: "selectpicker form-control show-tick" } %>
   <% end %>
   <%= f.text_area "dataset[description]", label: "Dataset description", value: dataset.description, placeholder: t(:'dataset.description')  %>
   <%= f.text_field "dataset[publisher_name]", label: "Publisher name", value: dataset.publisher_name, required: true, placeholder: t(:'dataset.publisher_name') %>

--- a/app/views/inferred_dataset_file_schemas/new.html.erb
+++ b/app/views/inferred_dataset_file_schemas/new.html.erb
@@ -10,7 +10,7 @@
   <% if SchemaCategory.any? %>
     <%= f.collection_check_boxes :schema_category_ids, SchemaCategory.all, :id, :name, label: 'Schema Categories' %>
   <% end %>
-  <%= f.select :owner_username, organization_select_options, { label: "Owner" }, { class: "selectpicker form-control show-tick" } %>
+  <%= f.select :owner_username, organization_select_options, { label: t(:'dataset_file_schema.owner') }, { class: "selectpicker form-control show-tick" } %>
   <%= f.select :restricted, dataset_file_schema_access_options, { label: "Access" }, { class: "selectpicker form-control show-tick" } %>
   <div class="schema-panel">
     <div class="panel panel-default">

--- a/app/views/output_schemas/new.html.erb
+++ b/app/views/output_schemas/new.html.erb
@@ -6,7 +6,7 @@
     <%= f.hidden_field :dataset_file_schema_id, value: @dataset_file_schema.id %>
     <%= f.text_field :title, required: true %>
     <%= f.text_area :description %>
-    <%= f.select :owner_username, organization_select_options, { label: "Owner" }, { class: "selectpicker form-control show-tick" } %>
+    <%= f.select :owner_username, organization_select_options, { label: t(:'output_schema.owner') }, { class: "selectpicker form-control show-tick" } %>
   </fieldset>
 
   <h2>Output Schema Fields <small>from <%= link_to @dataset_file_schema.name, dataset_file_schema_path(@dataset_file_schema) %></small></h2>
@@ -35,4 +35,3 @@
     </div>
 </div>
 <% end %>
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@
 en:
   dataset:
     name: A descriptive name for this dataset
+    owner: Organization
     description: >
       A detailed description of the dataset. Try including things like what the dataset
       covers, what it means, and how it should be interpreted.
@@ -35,6 +36,10 @@ en:
     description: >
       A detailed description of this particular file. Perhaps explain why someone would
       want this file instead of any other, what any unusual fields mean, and so on.
+  dataset_file_schema:
+    owner: Organization
+  output_schema:
+    owner: Organization
   allocated_schema_dataset_file:
     name: A descriptive name for this particular file
     description: >


### PR DESCRIPTION
Calling the github organization "owner" in the UI, is confusing when there is also a user who can edit the dataset. I've changed it to Organization to be clearer that it's not about actual ownership of the data.

I've not changed the database fields or code - this is just a UI translation for now.