### PR TITLE
updating old-octopub homepage, point to new-beta

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -13,5 +13,6 @@
   <% end %>
 </div>
 <div class="jumbotron">
-	<p>Octopub is currently under development. You can view the staging website <%= link_to "here", 'https://octopub-staging.herokuapp.com/', title: 'Octopub staging webs' %>.</p>
+	<p>This is an older version of the Octopub tool, and will be decommissioned at the end of 2018.
+    You can view the newer version  <%= link_to "here", 'https://octopub.io/', title: 'new Octopub Beta' %>.</p>
 </div>


### PR DESCRIPTION
This PR changes the warning text at the bottom of the old-octopub homepage, pointing to the new beta service instead.