### PR TITLE
Banner amendments and remove octopub summary splash from signed in homepage

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -1,8 +1,9 @@
 <% unless !current_user %>
 	<div class="home-box-beta">
 		<p>This is an early preview of a completely new user experience for Octopub.</p>
-		<p>Because it is in BETA you may encounter errors, in which case please raise an issue at <a href="https://github.com/theodi/octopub/issues" title="Octopub Github Issues" alt="Octopub Github Issues">Github</a> or contact us on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs.theodi.org</a></p>
-		<p>The old version of octopub is available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be deleted.  Please contact us on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs.theodi.org</a> if you urgently need to transfer details from the old system.  However all data on github will remain untouched and available indefinitely.</p>
+    <p>Please try it out and let us know what you think on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs@theodi.org</a>.  Although we don't advise you publish anything you want to manage on an ongoing basis until it stabilises.</p>
+		<p>Because it is in BETA you may encounter errors, in which case please raise an issue on <a href="https://github.com/theodi/octopub/issues" title="Octopub Github Issues" alt="Octopub Github Issues">Github</a> or <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">email us</a></p>
+		<p>The old experimental version of octopub is still available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be retired.  Please <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">contact us</a> if you urgently need to transfer any data from the old system.  Don't worry all data published on github will remain untouched and available indefinitely.</p>
 	</div>
 	<% if @datasets.count == 0 %>
     <div class="home-box-head">

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -2,8 +2,8 @@
 	<div class="home-box-beta">
 		<p>This is an early preview of a completely new user experience for Octopub.</p>
     <p>Please try it out and let us know what you think on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs@theodi.org</a>.  Although we don't advise you publish anything you want to manage on an ongoing basis until it stabilises.</p>
-		<p>Because it is in BETA you may encounter errors, in which case please raise an issue on <a href="https://github.com/theodi/octopub/issues" title="Octopub Github Issues" alt="Octopub Github Issues">Github</a> or <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">email us</a></p>
-		<p>The old experimental version of octopub is still available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be retired.  Please <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">contact us</a> if you urgently need to transfer any data from the old system.  Don't worry all data published on github will remain untouched and available indefinitely.</p>
+		<p>Because it is in BETA you may encounter errors, in which case please raise an issue on <a href="https://github.com/theodi/octopub/issues" title="Octopub GitHub Issues" alt="Octopub GitHub Issues">GitHub</a> or <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">email us</a></p>
+		<p>The old experimental version of octopub is still available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be retired.  Please <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">contact us</a> if you urgently need to transfer any data from the old system.  Don't worry all data published on GitHub will remain untouched and available indefinitely.</p>
 	</div>
   <div class="home-box-table">
     <h3 style="display: block">Quick actions:</h3>
@@ -78,14 +78,14 @@
 	<div class="home-box-beta">
     <p>This is an early preview of a completely new user experience for Octopub.</p>
     <p>Please try it out and let us know what you think on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs@theodi.org</a>.  Although we don't advise you publish anything you want to manage on an ongoing basis until it stabilises.</p>
-    <p>Because it is in BETA you may encounter errors, in which case please raise an issue on <a href="https://github.com/theodi/octopub/issues" title="Octopub Github Issues" alt="Octopub Github Issues">Github</a> or <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">email us</a></p>
-    <p>The old experimental version of octopub is still available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be retired.  Please <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">contact us</a> if you urgently need to transfer any data from the old system.  Don't worry all data published on github will remain untouched and available indefinitely.</p>
+    <p>Because it is in BETA you may encounter errors, in which case please raise an issue on <a href="https://github.com/theodi/octopub/issues" title="Octopub GitHub Issues" alt="Octopub GitHub Issues">GitHub</a> or <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">email us</a></p>
+    <p>The old experimental version of octopub is still available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be retired.  Please <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">contact us</a> if you urgently need to transfer any data from the old system.  Don't worry all data published on GitHub will remain untouched and available indefinitely.</p>
   </div>
 	<div class="home-box-head">
 		<h1 class="orange"><span class="pub">Octo</span>pub</h1>
 		<h1>EXPLORING THE <span>FUTURE</span> of </br> OPEN DATA <span>PUBLISHING</span></h1>
-		<p>An ODI experiment, Octopub offers simple way to prepare and check </br> a dataset, and publish it online onto the Github platform.</p>
-		<%= bs_button_to "No Github account? Get one", "https://github.com/join", :class => "btn btn-secondary" %>
+		<p>An ODI experiment, Octopub offers simple way to prepare and check </br> a dataset, and publish it online onto the GitHub platform.</p>
+		<%= bs_button_to "No GitHub account? Get one", "https://github.com/join", :class => "btn btn-secondary" %>
 		<%= bs_button_to "Sign in to start", "/auth/github", :class => "btn btn-primary" %>
 	</div>
 	<div class="home-box-black">

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -5,13 +5,6 @@
 		<p>Because it is in BETA you may encounter errors, in which case please raise an issue on <a href="https://github.com/theodi/octopub/issues" title="Octopub Github Issues" alt="Octopub Github Issues">Github</a> or <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">email us</a></p>
 		<p>The old experimental version of octopub is still available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be retired.  Please <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">contact us</a> if you urgently need to transfer any data from the old system.  Don't worry all data published on github will remain untouched and available indefinitely.</p>
 	</div>
-	<% if @datasets.count == 0 %>
-    <div class="home-box-head">
-      <h1 class="orange"><span class="pub">Octo</span>pub</h1>
-			<h1>EXPLORING THE <span>FUTURE</span> of </br> OPEN DATA <span>PUBLISHING</span></h1>
-			<p>An ODI experiment, Octopub offers a simple way to prepare and check </br> a dataset, and publish it online onto the Github platform.</p>
-    </div>
-	<% end %>
   <div class="home-box-table">
     <h3 style="display: block">Quick actions:</h3>
     <% if @datasets.count == 0 %>
@@ -83,10 +76,11 @@
 
 <% unless current_user %>
 	<div class="home-box-beta">
-		<p>This is an early preview of a completely new user experience for Octopub.</p>
-		<p>Because it is in BETA you may encounter errors, in which case please raise an issue at <a href="https://github.com/theodi/octopub/issues" title="Octopub Github Issues" alt="Octopub Github Issues">Github</a> or contact us on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs.theodi.org</a></p>
-		<p>The old version of octopub is available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be deleted.  Please contact us on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs.theodi.org</a> if you urgently need to transfer details from the old system.  However all data on github will remain untouched and available indefinitely.</p>
-	</div>
+    <p>This is an early preview of a completely new user experience for Octopub.</p>
+    <p>Please try it out and let us know what you think on <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">labs@theodi.org</a>.  Although we don't advise you publish anything you want to manage on an ongoing basis until it stabilises.</p>
+    <p>Because it is in BETA you may encounter errors, in which case please raise an issue on <a href="https://github.com/theodi/octopub/issues" title="Octopub Github Issues" alt="Octopub Github Issues">Github</a> or <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">email us</a></p>
+    <p>The old experimental version of octopub is still available <a href="https://octopub.herokuapp.com/" title="ODI Heroku App" alt="ODI Heroku App">here</a> until the end of 2018 after which it will be retired.  Please <a href="mailto:labs@theodi.org" title="Email the ODI Labs team" alt="Email the ODI Labs team">contact us</a> if you urgently need to transfer any data from the old system.  Don't worry all data published on github will remain untouched and available indefinitely.</p>
+  </div>
 	<div class="home-box-head">
 		<h1 class="orange"><span class="pub">Octo</span>pub</h1>
 		<h1>EXPLORING THE <span>FUTURE</span> of </br> OPEN DATA <span>PUBLISHING</span></h1>


### PR DESCRIPTION
Adds some more warnings about the experimental nature, corrects some typos, and removes octopub summary splash from signed in homepage (it's not in the Zeplin designs)